### PR TITLE
Do not encode explicit 0 for not before

### DIFF
--- a/src/doughnut/payloadVersions/0/index.js
+++ b/src/doughnut/payloadVersions/0/index.js
@@ -140,7 +140,7 @@ function encode(doughnutJSON) {
     DOMAIN_PAYLOADS_LIST_BYTE_LENGTH += permissions[key].length;
   });
 
-  const hasNotBefore = notBefore != null;
+  const hasNotBefore = notBefore != null && notBefore > 0;
 
   const doughnutLength =
     getPayloadMetadataLength(hasNotBefore) +
@@ -228,7 +228,7 @@ function decode(doughnut) {
   cursor += PUBLIC_KEY_BYTE_LENGTH;
 
   const expiry = LEBytesToNumber(doughnut, TIMESTAMP_BYTE_LENGTH, cursor);
-  let notBefore;
+  let notBefore = 0;
   cursor += TIMESTAMP_BYTE_LENGTH;
   if (hasNotBefore) {
     notBefore = LEBytesToNumber(doughnut, TIMESTAMP_BYTE_LENGTH, cursor);
@@ -260,18 +260,13 @@ function decode(doughnut) {
     permissions[domainName] = payload;
   }
 
-  const result = {
+  return {
     issuer,
     holder,
+    notBefore,
     expiry,
     permissions,
   }
-
-  if (notBefore) {
-    result.notBefore = notBefore;
-  }
-
-  return result;
 }
 
 module.exports = {

--- a/src/doughnut/payloadVersions/0/index.spec.js
+++ b/src/doughnut/payloadVersions/0/index.spec.js
@@ -72,7 +72,7 @@ beforeEach(() => {
  *********/
 
 describe("Payload Version 0", () => {
-  it("should encode and decode a valid doughnut payload without NotBefore", () => {
+  it("should encode and decode a valid doughnut payload with NotBefore unspecified", () => {
     const source = doughnutJSON;
     const doughnut = payloadVersion.encode(source);
     const decode = payloadVersion.decode(doughnut);
@@ -82,9 +82,11 @@ describe("Payload Version 0", () => {
     expect(decode.expiry).toEqual(source.expiry);
     expect(decode.notBefore).toEqual(0);
     expect(decode.permissions).toEqual(source.permissions);
+    // Not before bit is unset
+    expect(doughnut[0] & (1 << 7)).toEqual(0);
   });
 
-  it("should encode and decode a valid doughnut payload with NotBefore", () => {
+  it("should encode and decode a valid doughnut payload with NotBefore specified", () => {
     const source = doughnutJSONWithNotBefore;
     const doughnut = payloadVersion.encode(source);
     const decode = payloadVersion.decode(doughnut);
@@ -96,7 +98,7 @@ describe("Payload Version 0", () => {
     expect(decode.permissions).toEqual(source.permissions);
   });
 
-  it("should not encode NotBefore when set to zero", () => {
+  it("should not encode an explicit zero NotBefore", () => {
     const source = doughnutJSONWithZeroNotBefore;
     const doughnut = payloadVersion.encode(source);
     const decode = payloadVersion.decode(doughnut);
@@ -106,6 +108,8 @@ describe("Payload Version 0", () => {
     expect(decode.expiry).toEqual(source.expiry);
     expect(decode.notBefore).toEqual(source.notBefore);
     expect(decode.permissions).toEqual(source.permissions);
+    // Not before bit is unset
+    expect(doughnut[0] & (1 << 7)).toEqual(0);
   });
 });
 

--- a/src/doughnut/payloadVersions/0/index.spec.js
+++ b/src/doughnut/payloadVersions/0/index.spec.js
@@ -18,6 +18,7 @@ let issuerKeyPair;
 let holderKeyPair;
 let doughnutJSON;
 let doughnutJSONWithNotBefore;
+let doughnutJSONWithZeroNotBefore;
 
 beforeAll(async () => {
   await cryptoWaitReady();
@@ -50,6 +51,18 @@ beforeEach(() => {
       somethingElse: new Uint8Array([35, 231, 113, 42])
     }
   };
+
+  doughnutJSONWithZeroNotBefore = {
+    issuer: issuerKeyPair.publicKey,
+    holder: holderKeyPair.publicKey,
+    expiry: 555555,
+    notBefore: 0,
+    permissions: {
+      something: new Uint8Array([234, 111, 4, 186]),
+      somethingElse: new Uint8Array([35, 231, 113, 42])
+    }
+  };
+
 });
 
 
@@ -67,12 +80,24 @@ describe("Payload Version 0", () => {
     expect(decode.issuer).toEqual(source.issuer);
     expect(decode.holder).toEqual(source.holder);
     expect(decode.expiry).toEqual(source.expiry);
-    expect(decode.notBefore).toEqual(source.notBefore);
+    expect(decode.notBefore).toEqual(0);
     expect(decode.permissions).toEqual(source.permissions);
   });
 
   it("should encode and decode a valid doughnut payload with NotBefore", () => {
     const source = doughnutJSONWithNotBefore;
+    const doughnut = payloadVersion.encode(source);
+    const decode = payloadVersion.decode(doughnut);
+
+    expect(decode.issuer).toEqual(source.issuer);
+    expect(decode.holder).toEqual(source.holder);
+    expect(decode.expiry).toEqual(source.expiry);
+    expect(decode.notBefore).toEqual(source.notBefore);
+    expect(decode.permissions).toEqual(source.permissions);
+  });
+
+  it("should not encode NotBefore when set to zero", () => {
+    const source = doughnutJSONWithZeroNotBefore;
     const doughnut = payloadVersion.encode(source);
     const decode = payloadVersion.decode(doughnut);
 


### PR DESCRIPTION
Also decodes 'not before' as 0, instead of null